### PR TITLE
Adding missing array declaration for closed webforms

### DIFF
--- a/cu_unused_forms/cu_unused_forms.module
+++ b/cu_unused_forms/cu_unused_forms.module
@@ -53,6 +53,7 @@ function cu_unused_forms_list() {
   }
   // Load all the webform nids to use later on.
   $nodes = node_load_multiple($form_nids);
+  $disabled_count = array();
 
   foreach ($nodes as $node) {
     if ($node->webform['status'] == 0) {


### PR DESCRIPTION
To test make a form and go to Edit Webform then Webform Settings then Status of this form and select closed.

Closed form should show up in `reports/forms/unused`